### PR TITLE
fix: update publish workflow to use RELEASE_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Download the widget JavaScript file
           curl -L -o dist/assistant-widget.js \
-            -H "Authorization: Bearer ${{ secrets.CROSS_REPO_DOWNLOAD_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_TOKEN }}" \
             "${{ github.event.client_payload.artifacts.widget_js }}"
 
           # Verify download


### PR DESCRIPTION
## Summary
• Update publish workflow to use RELEASE_TOKEN instead of CROSS_REPO_DOWNLOAD_TOKEN
• Aligns workflow with existing repository secrets configuration

## Test plan
- [ ] Verify workflow still functions correctly with the updated token reference
- [ ] Confirm RELEASE_TOKEN has proper permissions for artifact downloads

🤖 Generated with [Claude Code](https://claude.ai/code)